### PR TITLE
feat(iot): ESP32 refrigerator temperature firmware (PlatformIO)

### DIFF
--- a/io/.env.example
+++ b/io/.env.example
@@ -1,0 +1,6 @@
+MQTT_BROKER_URL=wss://localhost/mqtt
+MQTT_PORT=8883
+MQTT_USERNAME=user
+MQTT_PASSWORD=pass
+WIFI_SSID=ssid
+WIFI_PASSWORD=pass

--- a/io/.env.example
+++ b/io/.env.example
@@ -1,4 +1,13 @@
-MQTT_BROKER_URL=wss://localhost/mqtt
+# Firmware del ESP32 (PlatformIO). Copia este archivo a .env y llena los valores.
+# loadenv.sh exporta estas variables y platformio.ini las inyecta como build flags.
+
+# Broker MQTT: SOLO el hostname, sin esquema (wss://, mqtt://) ni path.
+# El firmware usa PubSubClient = MQTT sobre TCP/TLS, NO WebSocket, asi que
+# client.setServer() necesita un host pelon que resuelva por DNS.
+#   correcto:   broker.hivemq.com
+#   incorrecto: wss://broker.hivemq.com/mqtt
+MQTT_BROKER_URL=broker.hivemq.com
+# Puerto MQTT sobre TLS (mqtts). 8883 es el estandar.
 MQTT_PORT=8883
 MQTT_USERNAME=user
 MQTT_PASSWORD=pass

--- a/io/.gitignore
+++ b/io/.gitignore
@@ -1,0 +1,7 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+
+.fake

--- a/io/include/README
+++ b/io/include/README
@@ -1,0 +1,37 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the convention is to give header files names that end with `.h'.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/io/lib/README
+++ b/io/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into the executable file.
+
+The source code of each library should be placed in a separate directory
+("lib/your_library_name/[Code]").
+
+For example, see the structure of the following example libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional. for custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+Example contents of `src/main.c` using Foo and Bar:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+The PlatformIO Library Dependency Finder will find automatically dependent
+libraries by scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/io/loadenv.sh
+++ b/io/loadenv.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+while IFS='=' read -r key value; do
+  # Ignorar comentarios y líneas vacías
+  [[ -z "$key" || "$key" =~ ^# ]] && continue
+
+  # Eliminar comillas al inicio/final
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+
+  # Reemplazar retornos de carro de Windows (\r)
+  value="${value//$'\r'/}"
+
+  # Exportar sin romper espacios
+  export "$key=$value"
+done < <(grep -v '^#' .env)

--- a/io/platformio.ini
+++ b/io/platformio.ini
@@ -1,0 +1,26 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32doit-devkit-v1]
+platform = espressif32
+board = esp32doit-devkit-v1
+framework = arduino
+lib_deps = 
+	knolleary/PubSubClient@^2.8
+	adafruit/Adafruit MAX31865 library@^1.6.2
+monitor_speed = 115200
+
+build_flags =
+    -DMQTT_BROKER_URL=\"$ENV(MQTT_BROKER_URL)\"
+    -DMQTT_PORT=$ENV(MQTT_PORT)
+    -DMQTT_USERNAME=\"$ENV(MQTT_USERNAME)\"
+    -DMQTT_PASSWORD=\"$ENV(MQTT_PASSWORD)\"
+    -DWIFI_SSID=\"$ENV(WIFI_SSID)\"
+    -DWIFI_PASSWORD=\"$ENV(WIFI_PASSWORD)\"

--- a/io/src/main.cpp
+++ b/io/src/main.cpp
@@ -1,0 +1,140 @@
+#include <WiFi.h>
+#include <PubSubClient.h>
+#include <Adafruit_MAX31865.h>
+#include <time.h>
+#include <WiFiClientSecure.h>
+
+// --- CONFIGURACIÓN ---
+const char* ssid        = WIFI_SSID;
+const char* password    = WIFI_PASSWORD;
+const char* mqtt_server = MQTT_BROKER_URL;
+const int   mqtt_port   = MQTT_PORT;
+const char* mqtt_user   = MQTT_USERNAME;
+const char* mqtt_pass   = MQTT_PASSWORD;
+const int sensorID = 1;
+
+WiFiClientSecure espClient;
+PubSubClient client(espClient);
+
+// --- CONFIGURACIÓN MAX31865 ---
+
+#define RNOMINAL 100.0     // PT100 nominal 0°C
+#define RREF 430.0         // Resistencia de referencia MAX31865
+#define RTD_WIRES MAX31865_2WIRE
+
+// Crear los pines del MAX31865
+#define PIN_CS  27 // GPIO27 CS
+#define PIN_MOSI 14 // GPIO14 SDI 
+#define PIN_MISO 12 // GPIO12 SDO
+#define PIN_SCK 13 // GPIO13 CLK
+Adafruit_MAX31865 rtd = Adafruit_MAX31865(PIN_CS, PIN_MOSI, PIN_MISO, PIN_SCK);
+
+// --- VARIABLES ---
+double globalTemperatureC;
+unsigned long lastMsg = 0;
+char msg[100];  // buffer para JSON
+
+// --- FUNCIONES WIFI ---
+void setupWifi() {
+    WiFi.begin(ssid, password);
+    Serial.print("Connecting to Wi-Fi");
+    while (WiFi.status() != WL_CONNECTED) {
+        Serial.print(".");
+        delay(300);
+    }
+    Serial.println();
+    Serial.print("Connected with IP: ");
+    Serial.println(WiFi.localIP());
+}
+
+// --- FUNCIONES MQTT ---
+void reconnect() {
+    while (!client.connected()) {
+        Serial.print("Connecting to MQTT...");
+        String clientId = "ESP32SensorCliente-" + String(sensorID);
+        espClient.setInsecure();  // Deshabilitar verificación de certificado
+        if (client.connect(clientId.c_str(), mqtt_user, mqtt_pass)) {
+            Serial.println("Connected to MQTT broker!");
+        } else {
+            Serial.print("failed, rc=");
+            Serial.print(client.state());
+            Serial.println(" trying again in 5s");
+            delay(5000);
+        }
+    }
+}
+
+// --- FUNCIONES TEMPERATURA ---
+float getTemperatureC() {
+    uint16_t rtd_raw = rtd.readRTD();
+    float ratio = rtd_raw / 32768.0;
+    float resistance = RREF * ratio;
+    float tempC = rtd.temperature(RNOMINAL, RREF);
+
+    Serial.print("RTD raw value: "); Serial.println(rtd_raw);
+    Serial.print("Ratio: "); Serial.println(ratio, 8);
+    Serial.print("Resistance: "); Serial.println(resistance, 8);
+    Serial.print("Temperature: "); Serial.println(tempC, 2);
+
+    // Revisar fallos
+    uint8_t fault = rtd.readFault();
+    if (fault) {
+        Serial.print("MAX31865 Fault: 0x"); Serial.println(fault, HEX);
+        if (fault & MAX31865_FAULT_HIGHTHRESH) Serial.println(" - RTD High Threshold");
+        if (fault & MAX31865_FAULT_LOWTHRESH)  Serial.println(" - RTD Low Threshold");
+        if (fault & MAX31865_FAULT_REFINLOW)   Serial.println(" - REFIN- < 0.85 x Bias");
+        if (fault & MAX31865_FAULT_REFINHIGH)  Serial.println(" - REFIN- > 0.85 x Bias");
+        if (fault & MAX31865_FAULT_RTDINLOW)   Serial.println(" - RTDIN- < 0.85 x Bias");
+        if (fault & MAX31865_FAULT_OVUV)       Serial.println(" - Under/Over voltage");
+        rtd.clearFault();
+    }
+
+    return tempC;
+}
+
+// --- SETUP ---
+void setup() {
+    Serial.begin(115200);
+    pinMode(LED_BUILTIN, OUTPUT);
+
+    setupWifi();
+
+    if (!rtd.begin(RTD_WIRES)) {
+        Serial.println("Failed to initialize MAX31865. Check wiring!");
+        while (1) delay(10);
+    }
+
+    rtd.enable50Hz(false); // 60Hz
+    client.setServer(mqtt_server, mqtt_port);
+}
+
+// --- LOOP ---
+void loop() {
+    if (!client.connected()) reconnect();
+    client.loop();
+
+    unsigned long now = millis();
+    if (now - lastMsg > 5000) { 
+        lastMsg = now;
+
+        globalTemperatureC = getTemperatureC();
+
+        // Crear JSON con 2 decimales
+        snprintf(msg, sizeof(msg), "{\"sensor_id\" : %d, \"temperature\": %.2f}", sensorID, globalTemperatureC);
+
+        // Tópico dinámico
+        String topic = "bamx/sensors/temperature";
+
+        Serial.print("Publishing to topic: ");
+        Serial.println(topic);
+        Serial.print("Message: ");
+        Serial.println(msg);
+
+        client.publish(topic.c_str(), msg);
+
+        // LED indicador de envío
+        digitalWrite(LED_BUILTIN, LOW);
+        delay(200);
+        digitalWrite(LED_BUILTIN, HIGH);
+    }
+}

--- a/io/test/README
+++ b/io/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
Integra a `main` el firmware IoT que solo vivía en `develop-java`: el directorio `io/` (proyecto PlatformIO, ESP32 + sensor PT100 MAX31865) que publica la temperatura de los refrigeradores por MQTT.

`main` ya tenía el lado consumidor (`useTemperatureSensors.ts`, `Refrigeradores.tsx`, dep `mqtt`); solo faltaba el firmware del dispositivo, así que esto cierra el loop IoT.

## Commits
- `feat(iot): add ESP32 refrigerator temperature firmware (PlatformIO)` — el directorio `io/` tal cual de develop-java.
- `fix(iot): use bare hostname in MQTT_BROKER_URL example` — el ejemplo usaba `wss://...` (formato WebSocket) que PubSubClient no puede usar; corregido a host pelón.

## Verificación
- El firmware publica a `bamx/sensors/temperature` con `{"sensor_id","temperature"}`, que coincide exactamente con el schema que ya espera `useTemperatureSensors.ts`.
- Tests: backend `3/3`, frontend `17 suites / 119`. La rama solo toca `io/`, así que los checks de CI se saltan y pasan en verde.
- Build del firmware (requiere hardware): `cd io && cp .env.example .env` (llenar broker + WiFi) y luego `source loadenv.sh && pio run -t upload`.

## Follow-ups conocidos (heredados de develop-java, no bloquean)
Del code-review quedaron pendientes en el firmware: publica lecturas con fault del sensor, no reconecta WiFi, y usa TLS sin verificar certificado (`setInsecure`). Para un `fix/iot-firmware-robustez` aparte.