### PR TITLE
Fix/session noise and image urls

### DIFF
--- a/backend/src/main/java/com/bamx/backend/auth/services/UsuarioService.java
+++ b/backend/src/main/java/com/bamx/backend/auth/services/UsuarioService.java
@@ -35,9 +35,6 @@ public class UsuarioService {
   private final Rol1005Repository rol1005Repository;
   private final FotoUsuarioService fotoUsuarioService;
 
-  @Value("${app.host.url}")
-  private String hostUrl;
-
   @Value("${app.empresa.suffix:}")
   private String empresaSuffixOverride;
 
@@ -83,9 +80,11 @@ public class UsuarioService {
             .orElseThrow(() -> new UserNotFoundException("No role found for the user."));
 
     boolean hasProfilePicture = fotoUsuarioService.hasProfilePicture(id);
+    // Ruta relativa: el frontend (getImage/axios) le antepone su baseURL. Evita
+    // acoplar la URL de la foto al host/túnel por el que se accede al backend.
     String profilePictureUrl =
         hasProfilePicture
-            ? hostUrl + "/api/foto-usuario/"
+            ? "/api/foto-usuario/"
             : "https://www.pngall.com/wp-content/uploads/5/User-Profile-PNG-High-Quality-Image.png";
 
     return InfoUsuario.builder()

--- a/backend/src/main/java/com/bamx/backend/services/LtpdService.java
+++ b/backend/src/main/java/com/bamx/backend/services/LtpdService.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -20,9 +19,6 @@ import org.springframework.stereotype.Service;
 public class LtpdService {
   private final LtpdRepository ltpdRepository;
   private final LtpdMapper ltpdMapper;
-
-  @Value("${app.host.url}")
-  private String hostUrl;
 
   public Page<LoteConImagenDto> findAll(int page, int size, String sortBy, String sortDir) {
     Sort.Order order =
@@ -49,7 +45,9 @@ public class LtpdService {
           }
 
           if (dto.getImage() != null) {
-            dto.setImage(hostUrl + "/api/public/fotos-inventarios/" + dto.getImage());
+            // Ruta relativa: el frontend le antepone su baseURL. Así la URL de
+            // imagen no queda acoplada al host/túnel por el que se accede al backend.
+            dto.setImage("/api/public/fotos-inventarios/" + dto.getImage());
           } else {
             dto.setImage(
                 "https://png.pngtree.com/png-vector/20221125/ourlarge/pngtree-no-image-available-icon-flatvector-illustration-pic-design-profile-vector-png-image_40966566.jpg");

--- a/backend/src/test/java/com/bamx/backend/services/LtpdServiceTest.java
+++ b/backend/src/test/java/com/bamx/backend/services/LtpdServiceTest.java
@@ -1,0 +1,81 @@
+package com.bamx.backend.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.bamx.backend.dtos.LoteConImagenDto;
+import com.bamx.backend.mappers.LtpdMapper;
+import com.bamx.backend.repositories.LtpdRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageImpl;
+
+@ExtendWith(MockitoExtension.class)
+class LtpdServiceTest {
+
+  @Mock private LtpdRepository ltpdRepository;
+  @Mock private LtpdMapper ltpdMapper;
+  @InjectMocks private LtpdService ltpdService;
+
+  private LoteConImagenDto lote(String id, LocalDateTime expiration, String image) {
+    return LoteConImagenDto.builder()
+        .product_id(id)
+        .expiration_date(expiration)
+        .image(image)
+        .build();
+  }
+
+  private <T> Map<String, T> byProductId(
+      List<LoteConImagenDto> lotes, Function<LoteConImagenDto, T> field) {
+    when(ltpdRepository.findAllLotes(any(Pageable.class))).thenReturn(new PageImpl<>(lotes));
+    return ltpdService.findAll(0, 10, "fchCaduc", "asc").getContent().stream()
+        .collect(Collectors.toMap(LoteConImagenDto::getProduct_id, field));
+  }
+
+  @Test
+  void rewritesStatusFromExpirationDate() {
+    LocalDate today = LocalDate.now();
+    Map<String, String> status =
+        byProductId(
+            List.of(
+                lote("sin-caducidad", null, "x"),
+                lote("hoy+1", today.plusDays(1).atStartOfDay(), "x"),
+                lote("hoy+2", today.plusDays(2).atStartOfDay(), "x"),
+                lote("hoy+5", today.plusDays(5).atStartOfDay(), "x"),
+                lote("hoy+6", today.plusDays(6).atStartOfDay(), "x")),
+            LoteConImagenDto::getStatus);
+
+    // expiracion null y <= 2 dias => critical; 3-5 dias => warning; > 5 => good
+    assertEquals("critical", status.get("sin-caducidad"));
+    assertEquals("critical", status.get("hoy+1"));
+    assertEquals("critical", status.get("hoy+2"));
+    assertEquals("warning", status.get("hoy+5"));
+    assertEquals("good", status.get("hoy+6"));
+  }
+
+  @Test
+  void buildsRelativeImageUrlAndFallsBackWhenMissing() {
+    LocalDateTime good = LocalDate.now().plusDays(10).atStartOfDay();
+    Map<String, String> image =
+        byProductId(
+            List.of(lote("con-imagen", good, "FRUT000GR.jpg"), lote("sin-imagen", good, null)),
+            LoteConImagenDto::getImage);
+
+    // Ruta relativa (el frontend antepone su baseURL), no acoplada al host del backend.
+    assertEquals("/api/public/fotos-inventarios/FRUT000GR.jpg", image.get("con-imagen"));
+    // Sin imagen => placeholder externo absoluto.
+    assertTrue(image.get("sin-imagen").startsWith("https://"));
+  }
+}

--- a/frontend/__tests__/components/ProductRow.test.tsx
+++ b/frontend/__tests__/components/ProductRow.test.tsx
@@ -259,7 +259,7 @@ describe("ProductRow", () => {
     expect(mockProps.handleSelect).toHaveBeenCalledWith("123");
   });
 
-  it("navigates to details when info button is pressed", () => {
+  it("navigates to details with a JSON-stringified item when info button is pressed", () => {
     const { navigate } = require("../../functions/NavigationService");
     const { getByTestId } = render(
       <TestWrapper>
@@ -267,25 +267,25 @@ describe("ProductRow", () => {
       </TestWrapper>
     );
 
-    // Find the info button by its FontAwesome6 icon
-    const infoButtons =
-      getByTestId("info-button") ||
-      (() => {
-        // Fallback: find by text content or other method
-        const { getAllByText } = render(
-          <TestWrapper>
-            <ProductRow {...mockProps} />
-          </TestWrapper>
-        );
-        return getAllByText("Test Product")[0].parent?.parent?.children[0];
-      });
+    fireEvent.press(getByTestId("info-button"));
 
-    if (infoButtons) {
-      fireEvent.press(infoButtons);
-      expect(navigate).toHaveBeenCalledWith("Details", {
-        product: mockProduct,
-      });
-    }
+    // DetailsScreen reads the `item` param and JSON.parses it (Lot shape).
+    // Passing the raw object under `product` is the bug we are fixing.
+    expect(navigate).toHaveBeenCalledWith(
+      "Details",
+      expect.objectContaining({ item: expect.any(String) })
+    );
+
+    const { item } = navigate.mock.calls[0][1];
+    expect(JSON.parse(item)).toEqual(
+      expect.objectContaining({
+        product_id: "123",
+        product_name: "Test Product",
+        type: "fruit",
+        type_id: "fruit01",
+        production_date: "2025-08-01",
+      })
+    );
   });
 
   it("applies selected styles when isSelected is true", () => {

--- a/frontend/api/apiService.ts
+++ b/frontend/api/apiService.ts
@@ -30,7 +30,7 @@ export const apiService = {
         console.log("Sesión cerrada correctamente.");
       }
     } catch (error) {
-      console.error("Error al cerrar sesión:", error);
+      console.log("Error al cerrar sesión:", error);
     } finally {
       replace("Auth");
     }
@@ -43,6 +43,9 @@ export const apiService = {
       return response.data.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
+        // Los 401 ya los maneja el interceptor de response (limpia sesión y
+        // redirige a login); no los registramos aquí para no ensuciar consola.
+        if (error.response.status === 401) return;
         console.error(
           `Error ${error.response.status}:`,
           error.response.data.message
@@ -57,7 +60,10 @@ export const apiService = {
       const uri = `data:image/jpeg;base64,${base64}`;
       return uri;
     } catch (e) {
-      console.error(e);
+      // Imagen no disponible (URL inalcanzable, sin foto, etc.): no es un error
+      // de la app — la UI cae al avatar/imagen por defecto. Lo dejamos como log
+      // discreto en vez de un ERROR rojo en consola.
+      console.log("No se pudo cargar la imagen:", url);
       return null;
     }
   },

--- a/frontend/api/axiosInstance.ts
+++ b/frontend/api/axiosInstance.ts
@@ -6,25 +6,46 @@ export const instance = axios.create({
   baseURL: process.env.EXPO_PUBLIC_API_URL || "http://localhost:8080",
 });
 
+// Rutas de auth cuyo 401 NO significa "sesión expirada" (es credenciales o
+// refresh inválido), así que no deben gatillar el cierre de sesión automático.
+// Mismas que el request interceptor deja pasar sin inyectar token.
+const AUTH_ROUTES = [
+  "/api/usuarios/login",
+  "/api/usuarios/refresh-token",
+  "/api/usuarios/logout",
+];
+
+// Single-flight guard: evita redirigir a login (y loguear) varias veces cuando
+// muchos requests fallan a la vez por la misma sesión expirada. Se re-arma solo
+// en cuanto vuelve a haber un token válido (login o refresh exitoso).
+let redirectingToAuth = false;
+
+// Cierra la sesión localmente: borra tokens y redirige a login una sola vez.
+// NO llama a /logout: si llegamos aquí el token ya está muerto, así que
+// blocklistearlo en el backend no aporta nada (y generaría otro 401 ruidoso).
+const endSession = async () => {
+  await deleteData("access");
+  await deleteData("refresh");
+  if (!redirectingToAuth) {
+    redirectingToAuth = true;
+    replace("Auth");
+  }
+};
+
 instance.interceptors.request.use(
   async (config) => {
-    if (
-      config.url === "/api/usuarios/login" ||
-      // config.url === "/api/auth/register" ||
-      config.url === "/api/usuarios/refresh-token" ||
-      config.url === "/api/usuarios/logout"
-    ) {
+    if (AUTH_ROUTES.includes(config.url ?? "")) {
       return config;
     }
 
     let access = await getData("access");
     if (!access || tokenExpired(access)) {
-      try {
-        access = await refreshToken();
-      } catch (error) {
-        await logOut();
-        throw error;
-      }
+      // refreshToken() ya limpia la sesión y redirige si falla; aquí solo
+      // dejamos propagar el error para abortar este request.
+      access = await refreshToken();
+    } else {
+      // Token sano: re-armamos el guard para un futuro 401 (p. ej. tras re-login).
+      redirectingToAuth = false;
     }
     config.headers.Authorization = `Bearer ${access}`;
 
@@ -35,18 +56,44 @@ instance.interceptors.request.use(
   }
 );
 
+// Maneja de forma centralizada los 401 que devuelve el backend para tokens que
+// el cliente creía válidos (p. ej. el JWT_SECRET cambió entre reinicios). Sin
+// esto, ese 401 llegaba a cada handler sin redirigir a login.
+instance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const status = error?.response?.status;
+    const url: string = error?.config?.url ?? "";
+    // Solo cerramos sesión por 401 de NUESTRA API (rutas relativas) que no sean
+    // de auth. Las imágenes externas (fallbacks absolutos de getImage) pasan por
+    // este mismo instance; su 401 no debe desloguear al usuario.
+    const isExternal = /^https?:\/\//i.test(url);
+    if (status === 401 && !isExternal && !AUTH_ROUTES.includes(url)) {
+      await endSession();
+    }
+    return Promise.reject(error);
+  }
+);
+
 export const tokenExpired = (token: string) => {
-  const payload = JSON.parse(atob(token.split(".")[1]));
-  const currentTime = Math.floor(Date.now() / 1000);
-  return payload.exp < currentTime;
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    const currentTime = Math.floor(Date.now() / 1000);
+    return payload.exp < currentTime;
+  } catch {
+    // Token malformado / indecodificable: tratarlo como expirado en vez de
+    // tirar una excepción no atrapada dentro del interceptor.
+    return true;
+  }
 };
 
 const refreshToken = async () => {
+  const refresh_token = await getData("refresh");
+  if (!refresh_token) {
+    await endSession();
+    throw new Error("No refresh token found");
+  }
   try {
-    const refresh_token = await getData("refresh");
-    if (!refresh_token) {
-      throw new Error("No refresh token found");
-    }
     const response = await instance.post("/api/usuarios/refresh-token", null, {
       headers: {
         Authorization: `Bearer ${refresh_token}`,
@@ -57,34 +104,12 @@ const refreshToken = async () => {
     if (refresh) {
       await saveData("refresh", refresh);
     }
+    redirectingToAuth = false;
     return access;
   } catch (error) {
-    replace("Auth");
-    console.log("Error al refrescar el token:", error);
+    console.log("Sesión expirada, redirigiendo a login.");
+    await endSession();
     throw error;
-  }
-};
-const logOut = async () => {
-  try {
-    const refresh_token = await getData("refresh");
-    if (!refresh_token) {
-      throw new Error("No refresh token found");
-    }
-    const response = await instance.post("/api/usuarios/logout", null, {
-      headers: {
-        Authorization: `Bearer ${refresh_token}`,
-      },
-    });
-    await deleteData("access");
-    await deleteData("refresh");
-
-    if (response.status === 200) {
-      console.log("Sesión cerrada correctamente.");
-    }
-  } catch (error) {
-    console.error("Error al cerrar sesión:", error);
-  } finally {
-    replace("Auth");
   }
 };
 

--- a/frontend/components/ProductCard/ProductCard.tsx
+++ b/frontend/components/ProductCard/ProductCard.tsx
@@ -14,6 +14,7 @@ import { styles } from "./styles";
 import { Lot } from "@/types/Lot";
 import DefaultProductImage from "@/components/DefaultProductImage/DefaultProductImage";
 import { isUsableImage } from "@/functions/isUsableImage";
+import { resolveImageUrl } from "@/functions/resolveImageUrl";
 
 interface ProductCardProps {
   item: Lot;
@@ -27,7 +28,8 @@ export default function ProductCard({ item }: ProductCardProps) {
 
   const [loading, setLoading] = useState<boolean>(true);
   const [imageFailed, setImageFailed] = useState<boolean>(false);
-  const showRealImage = isUsableImage(item.image) && !imageFailed;
+  const imageUrl = resolveImageUrl(item.image);
+  const showRealImage = isUsableImage(imageUrl) && !imageFailed;
 
   return (
     <View
@@ -38,7 +40,7 @@ export default function ProductCard({ item }: ProductCardProps) {
         {showRealImage ? (
           <>
             <Image
-              source={{ uri: item.image as string }}
+              source={{ uri: imageUrl as string }}
               style={styles.image}
               resizeMode="cover"
               onLoad={() => setLoading(false)}

--- a/frontend/components/ProductRow/ProductRow.tsx
+++ b/frontend/components/ProductRow/ProductRow.tsx
@@ -128,7 +128,18 @@ export default function ProductRow({
         />
         <TouchableOpacity
           testID="info-button"
-          onPress={() => navigate("Details", { product })}
+          onPress={() =>
+            navigate("Details", {
+              item: JSON.stringify({
+                product_id: productId,
+                product_name: productName,
+                type: prodType,
+                type_id: (product as any).type_id ?? null,
+                production_date: production_date ?? null,
+                image: (product as any).image ?? null,
+              }),
+            })
+          }
           style={{ padding: 6 }}
         >
           <FontAwesome5 name="info-circle" size={16} color="gray" />

--- a/frontend/functions/resolveImageUrl.ts
+++ b/frontend/functions/resolveImageUrl.ts
@@ -1,0 +1,23 @@
+// Resuelve una URL de imagen del backend a absoluta.
+//
+// El backend devuelve rutas relativas (p. ej. "/api/public/fotos-inventarios/XYZ"
+// o "/api/foto-usuario/") para no acoplar la URL al host/túnel por el que se le
+// accede. El componente <Image> de React Native necesita una URL absoluta, así
+// que le anteponemos la baseURL de la API. URLs ya absolutas (http/https) o data:
+// (base64) se dejan tal cual.
+//
+// Nota: el avatar que pasa por apiService.getImage NO necesita esto — axios ya
+// antepone la baseURL a las rutas relativas. Este helper es para los <Image>
+// que reciben la URL directo (ProductCard, DetailsScreen).
+
+const API_BASE = process.env.EXPO_PUBLIC_API_URL || "http://localhost:8080";
+
+export function resolveImageUrl(
+  url: string | null | undefined
+): string | null | undefined {
+  if (!url) return url;
+  const trimmed = url.trim();
+  if (trimmed === "") return trimmed;
+  if (/^(https?:|data:)/i.test(trimmed)) return trimmed;
+  return `${API_BASE.replace(/\/$/, "")}/${trimmed.replace(/^\//, "")}`;
+}

--- a/frontend/screens/DetailsScreen/DetailsScreen.tsx
+++ b/frontend/screens/DetailsScreen/DetailsScreen.tsx
@@ -14,6 +14,7 @@ import { selectTheme } from "@/slices/themeSlice";
 import { Lot } from "@/types/Lot";
 import DefaultProductImage from "@/components/DefaultProductImage/DefaultProductImage";
 import { isUsableImage } from "@/functions/isUsableImage";
+import { resolveImageUrl } from "@/functions/resolveImageUrl";
 
 const { height, width } = Dimensions.get("window");
 
@@ -23,14 +24,15 @@ export default function DetailsScreen() {
   const isDark = theme === "dark";
   const product: Lot | null = item ? JSON.parse(item as string) : null;
   const [imageFailed, setImageFailed] = useState<boolean>(false);
-  const showRealImage = isUsableImage(product?.image) && !imageFailed;
+  const imageUrl = resolveImageUrl(product?.image);
+  const showRealImage = isUsableImage(imageUrl) && !imageFailed;
 
   return (
     <View className={`flex-1 ${isDark ? "bg-black" : "bg-white"}`}>
       {/* Imagen superior */}
       {showRealImage ? (
         <Image
-          source={{ uri: product?.image as string }}
+          source={{ uri: imageUrl as string }}
           className="absolute top-0 left-0 w-full h-full"
           resizeMode="cover"
           onError={() => setImageFailed(true)}


### PR DESCRIPTION
## Contexto
Probando en el emulador de Android salían varios errores en consola que en realidad eran **dos problemas distintos** (no era el backend en localhost — el `.env` ya usa la IP de red y el backend responde):

1. **Sesión vieja/expirada** → cascada ruidosa: `Error al refrescar el token: 401` (x2), `Error al cerrar sesión: 401`, `Error 401: Failed to decode token (expired)`. Además, un 401 que el cliente creía válido (p. ej. si cambia el `JWT_SECRET`) no se manejaba en ningún lado.
2. **Imágenes rotas** → `AxiosError: Network Error`. Las URLs de imagen (avatar + lotes) se armaban con `app.host.url`, que apuntaba a un túnel de Cloudflare ya muerto.

## Qué incluye

### `fix(auth)` — manejo limpio de sesión expirada
- `endSession()` borra tokens y redirige a login **una sola vez** (single-flight guard), sin la llamada extra a `/logout`.
- Nuevo interceptor de **response**: un 401 de nuestra API también redirige a login. Acotado a rutas relativas y no-auth, para que un 401 de una imagen externa no te desloguee.
- `tokenExpired()` tolera tokens malformados en vez de tirar excepción.
- Se silencian los logs esperados (401 en `retrieveData`; fallos de logout/imagen pasan de `console.error` a log discreto).

### `fix(images)` — URLs de imagen relativas
- Backend devuelve rutas **relativas** (`/api/foto-usuario/`, `/api/public/fotos-inventarios/...`) y se elimina el campo `hostUrl` (ya sin uso).
- Frontend: `resolveImageUrl()` antepone la baseURL para los `<Image>` (ProductCard, DetailsScreen). El avatar vía `getImage` no cambia (axios ya antepone baseURL).
- Las imágenes ya no quedan acopladas al host/túnel por el que se accede al backend.

## Cómo probar
1. Reiniciar backend + recargar la app.
2. **Imágenes**: el avatar (SideBar/Usuario) y la imagen de un lote en Details cargan; sin banner rojo `Network Error`.
3. **Sesión**: con un token inválido (p. ej. cambiar `JWT_SECRET` y reiniciar), navegar → debe salir solo `Sesión expirada, redirigiendo a login.` y redirect limpio, sin la cascada de 401.

## Verificación
- Frontend: `tsc --noEmit` limpio · **119/119** tests.
- Backend: compila · **3/3** tests.

## Fuera de alcance / notas
- `EXPO_PUBLIC_MQTT_BROKER_URL=wss://localhost:1883` sigue mal para el emulador (refrigeradores/IoT) — pendiente aparte.
- Pre-existente: `ProductRow` navega a Details con un param que `DetailsScreen` no lee (`product` vs `item`), así que desde Inventario el Details sale sin imagen. No lo toca este PR.