### PR TITLE
Feat/pages entregables no aptos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ El sufijo en el ThreadLocal se setea por request en `JwtAuthenticationFilter` de
 | `/api/usuarios/logout` | POST | `UsuarioService.logout` | Inserta en `TOKEN_BLOCK_LIST` si existe |
 | `/api/usuarios/me` | GET | `UsuarioService.findById` | Usa `@CurrentUser` |
 | `/api/inventarios/` | GET | `InveService.getAllInve` | Page<InventoryItem>. Soporta `page,size,sort,direction,search` |
-| `/api/lotes/` | GET | `LtpdService.findAll` | Page<LoteConImagenDto> |
+| `/api/lotes/` | GET | `LtpdService.findAll` | Page<LoteConImagenDto>. `fitForDelivery` opcional: `true`=entregables (verde+amarillo), `false`=no aptos (rojo), ausente=todos (Semaforo) |
 | `/api/almacenes/all` | GET | `AlmacenService.getAllAlmacenes` | Lista de almacenes |
 | `/api/almacenes/dashboard` | GET | `AlmacenService.getDashboard` | Por almacén → por línea → totales critical/warning/good |
 | `/api/foto-usuario/` | GET | `FotoUsuarioController` | PNG del usuario actual |
@@ -222,6 +222,8 @@ app/
     ├── _layout.tsx          # Drawer + SideBar
     ├── inicio.tsx           # → HomeScreen
     ├── inventario.tsx       # → InventoryScreen
+    ├── productosEntregables.tsx # → ProductosEntregablesScreen (semáforo verde+amarillo)
+    ├── productosNoAptos.tsx     # → ProductosNoAptosScreen (semáforo rojo)
     └── usuario.tsx          # → UserScreen / ProfileScreen
 ```
 
@@ -235,8 +237,12 @@ Los archivos en `app/` son shims que importan de `screens/`. La lógica real viv
 | `/(auth)/login` | `AuthScreen` | Login username + password con fondo `bg-bamx.jpeg`. Llama `apiService.loginUser` |
 | `/(drawer)/inicio` | `HomeScreen` | `AnimatedSwitch` para alternar entre **Semaforo** (totales crítico/prioritario/estable + barra gradiente + lista) y **Refrigeradores** (cards de almacenes con temperatura) |
 | `/(drawer)/inventario` | `InventoryScreen` | `SearchHeader` (search + sort + dirección) + `ProductList` paginada con `ProductRow` |
+| `/(drawer)/productosEntregables` | `ProductosEntregablesScreen` | Grid de tarjetas (hero + buscador + chips de categoría + frescura) de productos **entregables** (semáforo verde+amarillo). Comparte `DeliverablesScreen` con la de no aptos |
+| `/(drawer)/productosNoAptos` | `ProductosNoAptosScreen` | Mismo grid, bucket **no apto** (semáforo rojo: caducados, por caducar ≤2d o sin caducidad). Acento rojo, frescura tipo "caducó hace Xd" |
 | `/(drawer)/usuario` | `UserScreen` | Avatar (o inicial) + nombre + email + empresa + rol + status |
 | `/details` (modal) | `DetailsScreen` | Imagen + nombre + tipo + clave + fechas en bottom-sheet. Recibe `item` por params (JSON-stringified) |
+
+> **Entregables / No aptos** comparten `components/DeliverablesScreen` (parametrizado por `variant`). El bucket lo decide la caducidad vía el filtro `fitForDelivery` de `/api/lotes/`: entregable = `fchCaduc > hoy+2` (frontera exacta `>= medianoche de hoy+3`, alineada con `days>2` de `LtpdService`), no apto = `fchCaduc <= hoy+2` o `NULL`. `useFetchDeliverables` agrega los lotes por producto (una tarjeta = un producto) y `getFreshness` traduce la caducidad a puntos+color+label. **Misma dependencia que el Semaforo**: si `LTPD` está vacío, estas pantallas también (por diseño — la caducidad manda). El empty state lo explica.
 
 ### Cliente HTTP
 - `api/axiosInstance.ts` → `instance` con `baseURL = EXPO_PUBLIC_API_URL`. Interceptor que:
@@ -485,7 +491,7 @@ Componente que recibe `typeId` (CVE_LIN, preferido) o `type` (DESC_LIN, fallback
 - `ProductRow` usa `(product as any)` para tragar `InventoryItem | Lot`.
 - `spring.jpa.open-in-view=true` (anti-pattern).
 - Tests en H2 ≠ Firebird real.
-- 2 botones del SideBar sin `onPress` (Productos entregables / Productos no aptos). El de "Registro" ya se quitó en `chore/ui-cleanup`.
+- ~~2 botones del SideBar sin `onPress` (Productos entregables / Productos no aptos)~~ ✅ **resueltos** en `feat/pages-entregables-no-aptos` (cablean a sus pantallas vía `DeliverablesScreen`). El de "Registro" ya se quitó en `chore/ui-cleanup`.
 
 **SUGGESTIONS**
 - Bajar a Java 21 LTS.

--- a/backend/src/main/java/com/bamx/backend/controllers/LtpdController.java
+++ b/backend/src/main/java/com/bamx/backend/controllers/LtpdController.java
@@ -24,9 +24,11 @@ public class LtpdController {
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size,
       @RequestParam(defaultValue = "fchCaduc") String sort,
-      @RequestParam(defaultValue = "asc") String direction) {
+      @RequestParam(defaultValue = "asc") String direction,
+      @RequestParam(required = false) Boolean fitForDelivery) {
 
-    Page<LoteConImagenDto> result = ltpdService.findAll(page, size, sort, direction);
+    Page<LoteConImagenDto> result =
+        ltpdService.findAll(page, size, sort, direction, fitForDelivery);
     HttpStatus status = HttpStatus.OK;
 
     return new ResponseEntity<>(

--- a/backend/src/main/java/com/bamx/backend/repositories/LtpdRepository.java
+++ b/backend/src/main/java/com/bamx/backend/repositories/LtpdRepository.java
@@ -38,6 +38,61 @@ public interface LtpdRepository extends JpaRepository<Ltpd, Integer> {
 """)
   Page<LoteConImagenDto> findAllLotes(Pageable pageable);
 
+  // Entregables (semáforo verde+amarillo): caducan a partir del cutoff (hoy+3 a medianoche),
+  // que coincide exacto con la frontera "days > 2" de LtpdService. NULL queda excluido.
+  @Query(
+"""
+    SELECT new com.bamx.backend.dtos.LoteConImagenDto(
+        l.cveArt,
+        i.descr,
+        i.linProd,
+        lp.descLin,
+        l.lote,
+        l.cantidad,
+        l.fecProdLt,
+        l.fchCaduc,
+        l.fchUltMov,
+        l.cveAlm,
+        null,
+        i.cveImagen
+    )
+    FROM Ltpd l
+    JOIN Inve i ON i.cveArt = l.cveArt
+    LEFT JOIN CLin lp ON lp.cveLin = i.linProd
+    WHERE l.cantidad > 0
+      AND l.status = 'A'
+      AND l.fchCaduc >= :deliverableCutoff
+""")
+  Page<LoteConImagenDto> findDeliverableLotes(
+      @Param("deliverableCutoff") LocalDateTime deliverableCutoff, Pageable pageable);
+
+  // No aptos (semáforo rojo): ya caducaron, caducan antes del cutoff, o no tienen caducidad capturada.
+  @Query(
+"""
+    SELECT new com.bamx.backend.dtos.LoteConImagenDto(
+        l.cveArt,
+        i.descr,
+        i.linProd,
+        lp.descLin,
+        l.lote,
+        l.cantidad,
+        l.fecProdLt,
+        l.fchCaduc,
+        l.fchUltMov,
+        l.cveAlm,
+        null,
+        i.cveImagen
+    )
+    FROM Ltpd l
+    JOIN Inve i ON i.cveArt = l.cveArt
+    LEFT JOIN CLin lp ON lp.cveLin = i.linProd
+    WHERE l.cantidad > 0
+      AND l.status = 'A'
+      AND (l.fchCaduc < :deliverableCutoff OR l.fchCaduc IS NULL)
+""")
+  Page<LoteConImagenDto> findNotDeliverableLotes(
+      @Param("deliverableCutoff") LocalDateTime deliverableCutoff, Pageable pageable);
+
   @Query(
       """
           SELECT a.descr

--- a/backend/src/main/java/com/bamx/backend/services/LtpdService.java
+++ b/backend/src/main/java/com/bamx/backend/services/LtpdService.java
@@ -5,6 +5,7 @@ import com.bamx.backend.dtos.LtpdDto;
 import com.bamx.backend.mappers.LtpdMapper;
 import com.bamx.backend.repositories.LtpdRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,14 +21,38 @@ public class LtpdService {
   private final LtpdRepository ltpdRepository;
   private final LtpdMapper ltpdMapper;
 
+  /** Sin filtro de entregabilidad: lo usa el Semáforo (Home). No tocar el comportamiento. */
   public Page<LoteConImagenDto> findAll(int page, int size, String sortBy, String sortDir) {
+    return findAll(page, size, sortBy, sortDir, null);
+  }
+
+  /**
+   * @param fitForDelivery {@code null} = todos los lotes (Semáforo); {@code true} = solo
+   *     entregables (verde+amarillo); {@code false} = solo no aptos (rojo: caducados, por caducar o
+   *     sin caducidad capturada).
+   */
+  public Page<LoteConImagenDto> findAll(
+      int page, int size, String sortBy, String sortDir, Boolean fitForDelivery) {
     Sort.Order order =
         new Sort.Order(
             sortDir.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC,
             sortBy == null ? "fchCaduc" : sortBy);
     Pageable pageable = PageRequest.of(page, size, Sort.by(order));
-    Page<LoteConImagenDto> pages = ltpdRepository.findAllLotes(pageable);
     LocalDate today = LocalDate.now();
+
+    Page<LoteConImagenDto> pages;
+    if (fitForDelivery == null) {
+      pages = ltpdRepository.findAllLotes(pageable);
+    } else {
+      // Entregable <=> "days > 2" en la clasificación de abajo. Como days se calcula truncando la
+      // caducidad a fecha, la frontera cae exacta en la medianoche de hoy+3.
+      LocalDateTime deliverableCutoff = today.plusDays(3).atStartOfDay();
+      pages =
+          fitForDelivery
+              ? ltpdRepository.findDeliverableLotes(deliverableCutoff, pageable)
+              : ltpdRepository.findNotDeliverableLotes(deliverableCutoff, pageable);
+    }
+
     return pages.map(
         dto -> {
           if (dto.getExpiration_date() == null) {

--- a/backend/src/test/java/com/bamx/backend/services/LtpdServiceTest.java
+++ b/backend/src/test/java/com/bamx/backend/services/LtpdServiceTest.java
@@ -3,6 +3,8 @@ package com.bamx.backend.services;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.bamx.backend.dtos.LoteConImagenDto;
@@ -16,11 +18,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class LtpdServiceTest {
@@ -77,5 +80,67 @@ class LtpdServiceTest {
     assertEquals("/api/public/fotos-inventarios/FRUT000GR.jpg", image.get("con-imagen"));
     // Sin imagen => placeholder externo absoluto.
     assertTrue(image.get("sin-imagen").startsWith("https://"));
+  }
+
+  @Test
+  void defaultFindAllDoesNotFilterByDeliverability() {
+    // El Semáforo usa la firma de 4 args -> findAllLotes sin filtro de entregabilidad.
+    when(ltpdRepository.findAllLotes(any(Pageable.class)))
+        .thenReturn(
+            new PageImpl<>(List.of(lote("x", LocalDate.now().plusDays(10).atStartOfDay(), "x"))));
+
+    ltpdService.findAll(0, 10, "fchCaduc", "asc");
+
+    verify(ltpdRepository).findAllLotes(any(Pageable.class));
+    verify(ltpdRepository, never()).findDeliverableLotes(any(LocalDateTime.class), any());
+    verify(ltpdRepository, never()).findNotDeliverableLotes(any(LocalDateTime.class), any());
+  }
+
+  @Test
+  void fitForDeliveryTrueUsesDeliverableQueryWithMidnightOfTodayPlus3Cutoff() {
+    LocalDateTime expectedCutoff = LocalDate.now().plusDays(3).atStartOfDay();
+    when(ltpdRepository.findDeliverableLotes(any(LocalDateTime.class), any(Pageable.class)))
+        .thenReturn(
+            new PageImpl<>(
+                List.of(
+                    lote("warning", LocalDate.now().plusDays(4).atStartOfDay(), "x"),
+                    lote("good", LocalDate.now().plusDays(10).atStartOfDay(), "x"))));
+
+    var result = ltpdService.findAll(0, 10, "fchCaduc", "asc", true);
+
+    ArgumentCaptor<LocalDateTime> cutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(ltpdRepository).findDeliverableLotes(cutoff.capture(), any(Pageable.class));
+    verify(ltpdRepository, never()).findAllLotes(any(Pageable.class));
+    assertEquals(expectedCutoff, cutoff.getValue());
+
+    Map<String, String> status =
+        result.getContent().stream()
+            .collect(
+                Collectors.toMap(LoteConImagenDto::getProduct_id, LoteConImagenDto::getStatus));
+    assertEquals("warning", status.get("warning"));
+    assertEquals("good", status.get("good"));
+  }
+
+  @Test
+  void fitForDeliveryFalseUsesNotDeliverableQuery() {
+    when(ltpdRepository.findNotDeliverableLotes(any(LocalDateTime.class), any(Pageable.class)))
+        .thenReturn(
+            new PageImpl<>(
+                List.of(
+                    lote("sin-caducidad", null, "x"),
+                    lote("caducado", LocalDate.now().minusDays(1).atStartOfDay(), "x"))));
+
+    var result = ltpdService.findAll(0, 10, "fchCaduc", "asc", false);
+
+    verify(ltpdRepository).findNotDeliverableLotes(any(LocalDateTime.class), any(Pageable.class));
+    verify(ltpdRepository, never()).findAllLotes(any(Pageable.class));
+
+    Map<String, String> status =
+        result.getContent().stream()
+            .collect(
+                Collectors.toMap(LoteConImagenDto::getProduct_id, LoteConImagenDto::getStatus));
+    // El rewrite de status sigue aplicando aunque el filtrado lo haga la query.
+    assertEquals("critical", status.get("sin-caducidad"));
+    assertEquals("critical", status.get("caducado"));
   }
 }

--- a/frontend/__tests__/functions/getFreshness.test.ts
+++ b/frontend/__tests__/functions/getFreshness.test.ts
@@ -1,0 +1,68 @@
+import {
+  getFreshness,
+  FRESHNESS_GREEN,
+  FRESHNESS_AMBER,
+  FRESHNESS_RED,
+} from "@/functions/getFreshness";
+
+// Construye una caducidad ISO local a `days` días de hoy (al mediodía, para no
+// pelear con zonas horarias en el truncado a fecha).
+function expIn(days: number): string {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() + days);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}T12:00:00`;
+}
+
+describe("getFreshness - entregables", () => {
+  it("verde y muchos puntos cuando caduca holgado", () => {
+    const f = getFreshness(expIn(20), "entregable");
+    expect(f.color).toBe(FRESHNESS_GREEN);
+    expect(f.dots).toBe(5);
+    expect(f.daysLeft).toBe(20);
+    expect(f.label).toBe("Caduca en 20 días");
+  });
+
+  it("amarillo y pocos puntos cuando está por caducar (warning)", () => {
+    const f = getFreshness(expIn(4), "entregable");
+    expect(f.color).toBe(FRESHNESS_AMBER);
+    expect(f.dots).toBe(2);
+    expect(f.label).toBe("Caduca en 4 días");
+  });
+
+  it("usa 'mañana' para el día siguiente", () => {
+    const f = getFreshness(expIn(1), "entregable");
+    expect(f.label).toBe("Caduca mañana");
+    expect(f.dots).toBe(1);
+  });
+
+  it("sin caducidad => sin puntos", () => {
+    const f = getFreshness(null, "entregable");
+    expect(f.dots).toBe(0);
+    expect(f.label).toBe("Sin caducidad");
+  });
+});
+
+describe("getFreshness - no aptos", () => {
+  it("rojo y explica cuántos días lleva caducado", () => {
+    const f = getFreshness(expIn(-2), "noapto");
+    expect(f.color).toBe(FRESHNESS_RED);
+    expect(f.dots).toBe(0);
+    expect(f.label).toBe("Caducó hace 2 días");
+  });
+
+  it("rojo con 'Caduca hoy' cuando vence hoy", () => {
+    const f = getFreshness(expIn(0), "noapto");
+    expect(f.color).toBe(FRESHNESS_RED);
+    expect(f.label).toBe("Caduca hoy");
+  });
+
+  it("rojo con 'Sin caducidad' cuando no hay fecha capturada", () => {
+    const f = getFreshness(null, "noapto");
+    expect(f.color).toBe(FRESHNESS_RED);
+    expect(f.label).toBe("Sin caducidad");
+  });
+});

--- a/frontend/__tests__/screens/DeliverablesScreen.test.tsx
+++ b/frontend/__tests__/screens/DeliverablesScreen.test.tsx
@@ -35,8 +35,8 @@ const product = (over: Partial<DeliverableProduct>): DeliverableProduct => ({
 function setHook(over: Partial<ReturnType<typeof mockUse>> = {}) {
   mockUse.mockReturnValue({
     products: [],
-    totalQuantity: 0,
     totalCount: 0,
+    truncated: false,
     loading: false,
     refresh: jest.fn(),
     ...over,
@@ -82,5 +82,16 @@ describe("DeliverablesScreen", () => {
     const { getByText } = renderScreen("noapto");
     expect(getByText("Productos no aptos")).toBeTruthy();
     expect(getByText("Nada marcado como no apto")).toBeTruthy();
+  });
+
+  it("muestra aviso de lista parcial cuando el bucket viene truncado", () => {
+    setHook({
+      products: [product({})],
+      totalCount: 1,
+      truncated: true,
+      loading: false,
+    });
+    const { getByText } = renderScreen("entregable");
+    expect(getByText(/Lista parcial/)).toBeTruthy();
   });
 });

--- a/frontend/__tests__/screens/DeliverablesScreen.test.tsx
+++ b/frontend/__tests__/screens/DeliverablesScreen.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { TestWrapper } from "../utils/testUtils";
+import DeliverablesScreen from "@/components/DeliverablesScreen/DeliverablesScreen";
+import { DeliverableProduct } from "@/types/DeliverableProduct";
+
+// El modal de detalles navega por aquí; lo mockeamos para no tocar expo-router.
+jest.mock("@/functions/NavigationService", () => ({ navigate: jest.fn() }));
+
+// Controlamos los datos mockeando el hook (la agregación/fetch se prueba aparte).
+const mockUse = jest.fn();
+jest.mock("@/hooks/useFetchDeliverables", () => ({
+  __esModule: true,
+  default: (variant: string) => mockUse(variant),
+}));
+
+function futureISO(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+}
+
+const product = (over: Partial<DeliverableProduct>): DeliverableProduct => ({
+  product_id: "P1",
+  product_name: "Fruta a granel",
+  type: "FRUTA PERECEDERA",
+  type_id: "FYV",
+  image: null,
+  total_quantity: 57,
+  nearest_expiration: futureISO(10),
+  lots_count: 1,
+  ...over,
+});
+
+function setHook(over: Partial<ReturnType<typeof mockUse>> = {}) {
+  mockUse.mockReturnValue({
+    products: [],
+    totalQuantity: 0,
+    totalCount: 0,
+    loading: false,
+    refresh: jest.fn(),
+    ...over,
+  });
+}
+
+const renderScreen = (variant: "entregable" | "noapto") =>
+  render(
+    <TestWrapper>
+      <DeliverablesScreen variant={variant} />
+    </TestWrapper>
+  );
+
+describe("DeliverablesScreen", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("muestra título y resumen del bucket entregable", () => {
+    setHook({ products: [], totalCount: 0, loading: false });
+    const { getByText } = renderScreen("entregable");
+    expect(getByText("Productos entregables")).toBeTruthy();
+    expect(getByText("0 productos listos para entregar")).toBeTruthy();
+  });
+
+  it("muestra un empty state honesto cuando no hay productos", () => {
+    setHook({ products: [], totalCount: 0, loading: false });
+    const { getByText } = renderScreen("entregable");
+    expect(getByText("Aún no hay productos entregables")).toBeTruthy();
+  });
+
+  it("renderiza una tarjeta por producto", () => {
+    const products = [
+      product({ product_id: "P1", product_name: "Fruta a granel" }),
+      product({ product_id: "P2", product_name: "Yoghurt natural" }),
+    ];
+    setHook({ products, totalCount: 2, loading: false });
+    const { getByText } = renderScreen("entregable");
+    expect(getByText("Fruta a granel")).toBeTruthy();
+    expect(getByText("Yoghurt natural")).toBeTruthy();
+  });
+
+  it("usa el título y el empty state de no aptos en su variant", () => {
+    setHook({ products: [], totalCount: 0, loading: false });
+    const { getByText } = renderScreen("noapto");
+    expect(getByText("Productos no aptos")).toBeTruthy();
+    expect(getByText("Nada marcado como no apto")).toBeTruthy();
+  });
+});

--- a/frontend/app/(drawer)/productosEntregables.tsx
+++ b/frontend/app/(drawer)/productosEntregables.tsx
@@ -1,0 +1,5 @@
+import ProductosEntregablesScreen from "@/screens/ProductosEntregablesScreen/ProductosEntregablesScreen";
+
+export default function ProductosEntregablesPage() {
+  return <ProductosEntregablesScreen />;
+}

--- a/frontend/app/(drawer)/productosNoAptos.tsx
+++ b/frontend/app/(drawer)/productosNoAptos.tsx
@@ -1,0 +1,5 @@
+import ProductosNoAptosScreen from "@/screens/ProductosNoAptosScreen/ProductosNoAptosScreen";
+
+export default function ProductosNoAptosPage() {
+  return <ProductosNoAptosScreen />;
+}

--- a/frontend/components/CategoryChips/CategoryChips.tsx
+++ b/frontend/components/CategoryChips/CategoryChips.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { ScrollView, TouchableOpacity, Text, View } from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { resolveDefaultImage } from "@/components/DefaultProductImage/DefaultProductImage";
+
+export type Category = {
+  id: string; // CVE_LIN (type_id); "" para los sin línea
+  label: string; // nombre humano (DESC_LIN)
+  typeId: string | null;
+  type: string | null;
+  count: number;
+};
+
+type Props = {
+  categories: Category[];
+  selected: string | null; // null = "Todos"
+  onSelect: (id: string | null) => void;
+  isDark: boolean;
+};
+
+type IconName = React.ComponentProps<typeof MaterialCommunityIcons>["name"];
+
+function Chip({
+  active,
+  label,
+  icon,
+  color,
+  count,
+  isDark,
+  onPress,
+}: {
+  active: boolean;
+  label: string;
+  icon: IconName;
+  color: string;
+  count?: number;
+  isDark: boolean;
+  onPress: () => void;
+}) {
+  const idleBg = isDark ? "#27272a" : "#f1f0ec";
+  const idleText = isDark ? "#e4e4e7" : "#3f3f46";
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.8}
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        paddingVertical: 8,
+        paddingHorizontal: 14,
+        borderRadius: 999,
+        backgroundColor: active ? color : idleBg,
+        borderWidth: 1,
+        borderColor: active ? color : "transparent",
+      }}
+    >
+      <MaterialCommunityIcons
+        name={icon}
+        size={16}
+        color={active ? "#fff" : color}
+      />
+      <Text
+        style={{
+          marginLeft: 6,
+          fontWeight: "600",
+          fontSize: 13,
+          color: active ? "#fff" : idleText,
+        }}
+      >
+        {label}
+      </Text>
+      {typeof count === "number" && (
+        <View
+          style={{
+            marginLeft: 6,
+            minWidth: 20,
+            paddingHorizontal: 5,
+            paddingVertical: 1,
+            borderRadius: 999,
+            backgroundColor: active ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.06)",
+            alignItems: "center",
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 11,
+              fontWeight: "700",
+              color: active ? "#fff" : idleText,
+            }}
+          >
+            {count}
+          </Text>
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+// Fila de chips para filtrar el grid por línea de producto (CVE_LIN). Reusa la
+// paleta/iconos de DefaultProductImage (resolveDefaultImage) para que cada
+// categoría tenga el mismo color e icono que en las tarjetas.
+export default function CategoryChips({
+  categories,
+  selected,
+  onSelect,
+  isDark,
+}: Props) {
+  const totalCount = categories.reduce((s, c) => s + c.count, 0);
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{ gap: 8, paddingHorizontal: 16, paddingVertical: 4 }}
+    >
+      <Chip
+        active={selected == null}
+        label="Todos"
+        icon="shape-outline"
+        color="#6366f1"
+        count={totalCount}
+        isDark={isDark}
+        onPress={() => onSelect(null)}
+      />
+      {categories.map((c) => {
+        const { bgColor, icon } = resolveDefaultImage({
+          typeId: c.typeId,
+          type: c.type,
+        });
+        return (
+          <Chip
+            key={c.id}
+            active={selected === c.id}
+            label={c.label}
+            icon={icon}
+            color={bgColor}
+            count={c.count}
+            isDark={isDark}
+            onPress={() => onSelect(c.id)}
+          />
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/frontend/components/DeliverableCard/DeliverableCard.tsx
+++ b/frontend/components/DeliverableCard/DeliverableCard.tsx
@@ -1,0 +1,206 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+} from "react-native";
+import { navigate } from "@/functions/NavigationService";
+import { isUsableImage } from "@/functions/isUsableImage";
+import { resolveImageUrl } from "@/functions/resolveImageUrl";
+import { formatQuantity } from "@/functions/formatQuantity";
+import { unitForLine } from "@/functions/unitForLine";
+import {
+  getFreshness,
+  FRESHNESS_GREEN,
+  FRESHNESS_AMBER,
+} from "@/functions/getFreshness";
+import DefaultProductImage from "@/components/DefaultProductImage/DefaultProductImage";
+import FreshnessDots from "@/components/FreshnessDots/FreshnessDots";
+import {
+  DeliverableProduct,
+  DeliverableVariant,
+} from "@/types/DeliverableProduct";
+
+type Props = {
+  product: DeliverableProduct;
+  variant: DeliverableVariant;
+  width?: number;
+  isDark: boolean;
+};
+
+const MEDIA_HEIGHT = 132;
+
+// Texto legible sobre el color del badge (el amarillo necesita texto oscuro).
+function badgeTextColor(bg: string): string {
+  return bg === FRESHNESS_AMBER ? "#1a1a1a" : "#ffffff";
+}
+
+function statusLabel(variant: DeliverableVariant, color: string): string {
+  if (variant === "noapto") return "No apto";
+  return color === FRESHNESS_GREEN ? "Entregable" : "Por caducar";
+}
+
+// Tarjeta de producto para las pantallas de entregables / no aptos. Reusa el
+// patrón de imagen de ProductCard (URL real -> fallback DefaultProductImage por
+// categoría) y muestra cantidad agregada + indicador de frescura. Al tocarla
+// abre el modal de detalles existente.
+export default function DeliverableCard({
+  product,
+  variant,
+  width,
+  isDark,
+}: Props) {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [imageFailed, setImageFailed] = useState<boolean>(false);
+
+  const fresh = getFreshness(product.nearest_expiration, variant);
+  const imageUrl = resolveImageUrl(product.image);
+  const showRealImage = isUsableImage(imageUrl) && !imageFailed;
+  const unit = unitForLine({ typeId: product.type_id, type: product.type });
+
+  const detailItem = JSON.stringify({
+    product_id: product.product_id,
+    product_name: product.product_name,
+    type: product.type,
+    type_id: product.type_id,
+    production_date: null,
+    expiration_date: product.nearest_expiration,
+    image: product.image,
+  });
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.85}
+      onPress={() => navigate("Details", { item: detailItem })}
+      style={{
+        width,
+        borderRadius: 24,
+        overflow: "hidden",
+        backgroundColor: isDark ? "#1f2937" : "#ffffff",
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: isDark ? 0.4 : 0.12,
+        shadowRadius: 8,
+        elevation: 4,
+      }}
+    >
+      {/* Media + badge de estado */}
+      <View style={{ height: MEDIA_HEIGHT, width: "100%" }}>
+        {showRealImage ? (
+          <>
+            <Image
+              source={{ uri: imageUrl as string }}
+              style={{ width: "100%", height: MEDIA_HEIGHT }}
+              resizeMode="cover"
+              onLoad={() => setLoading(false)}
+              onError={() => {
+                setImageFailed(true);
+                setLoading(false);
+              }}
+            />
+            {loading && (
+              <View
+                testID="loading-indicator"
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <ActivityIndicator size="small" />
+              </View>
+            )}
+          </>
+        ) : (
+          <DefaultProductImage
+            typeId={product.type_id}
+            type={product.type}
+            size={MEDIA_HEIGHT}
+            style={{ width: "100%", height: MEDIA_HEIGHT }}
+          />
+        )}
+
+        <View
+          style={{
+            position: "absolute",
+            top: 8,
+            left: 8,
+            paddingHorizontal: 10,
+            paddingVertical: 4,
+            borderRadius: 999,
+            backgroundColor: fresh.color,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 11,
+              fontWeight: "700",
+              color: badgeTextColor(fresh.color),
+            }}
+          >
+            {statusLabel(variant, fresh.color)}
+          </Text>
+        </View>
+      </View>
+
+      {/* Cuerpo */}
+      <View style={{ paddingHorizontal: 14, paddingTop: 10, paddingBottom: 14 }}>
+        <Text
+          numberOfLines={2}
+          style={{
+            fontWeight: "600",
+            fontSize: 14,
+            minHeight: 38,
+            color: isDark ? "#f4f4f5" : "#18181b",
+          }}
+        >
+          {product.product_name}
+        </Text>
+
+        <View style={{ flexDirection: "row", alignItems: "baseline", marginTop: 4 }}>
+          <Text
+            style={{
+              fontSize: 20,
+              fontWeight: "800",
+              color: isDark ? "#ffffff" : "#111827",
+            }}
+          >
+            {formatQuantity(product.total_quantity)}
+          </Text>
+          <Text
+            style={{
+              marginLeft: 4,
+              fontSize: 12,
+              color: isDark ? "#9ca3af" : "#6b7280",
+            }}
+          >
+            {unit}
+          </Text>
+        </View>
+
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginTop: 10,
+          }}
+        >
+          <FreshnessDots dots={fresh.dots} color={fresh.color} />
+          <Text
+            numberOfLines={1}
+            style={{ fontSize: 11, fontWeight: "600", color: fresh.color, flexShrink: 1, textAlign: "right", marginLeft: 8 }}
+          >
+            {fresh.label}
+          </Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}

--- a/frontend/components/DeliverableCard/DeliverableCard.tsx
+++ b/frontend/components/DeliverableCard/DeliverableCard.tsx
@@ -11,11 +11,7 @@ import { isUsableImage } from "@/functions/isUsableImage";
 import { resolveImageUrl } from "@/functions/resolveImageUrl";
 import { formatQuantity } from "@/functions/formatQuantity";
 import { unitForLine } from "@/functions/unitForLine";
-import {
-  getFreshness,
-  FRESHNESS_GREEN,
-  FRESHNESS_AMBER,
-} from "@/functions/getFreshness";
+import { getFreshness, FRESHNESS_AMBER } from "@/functions/getFreshness";
 import DefaultProductImage from "@/components/DefaultProductImage/DefaultProductImage";
 import FreshnessDots from "@/components/FreshnessDots/FreshnessDots";
 import {
@@ -37,9 +33,10 @@ function badgeTextColor(bg: string): string {
   return bg === FRESHNESS_AMBER ? "#1a1a1a" : "#ffffff";
 }
 
-function statusLabel(variant: DeliverableVariant, color: string): string {
+function statusLabel(variant: DeliverableVariant, daysLeft: number | null): string {
   if (variant === "noapto") return "No apto";
-  return color === FRESHNESS_GREEN ? "Entregable" : "Por caducar";
+  // Verde (> 5 días) = entregable holgado; amarillo (3-5) = por caducar.
+  return daysLeft != null && daysLeft > 5 ? "Entregable" : "Por caducar";
 }
 
 // Tarjeta de producto para las pantallas de entregables / no aptos. Reusa el
@@ -144,7 +141,7 @@ export default function DeliverableCard({
               color: badgeTextColor(fresh.color),
             }}
           >
-            {statusLabel(variant, fresh.color)}
+            {statusLabel(variant, fresh.daysLeft)}
           </Text>
         </View>
       </View>

--- a/frontend/components/DeliverablesScreen/DeliverablesScreen.tsx
+++ b/frontend/components/DeliverablesScreen/DeliverablesScreen.tsx
@@ -67,17 +67,31 @@ export default function DeliverablesScreen({
   const { width: screenW } = useWindowDimensions();
 
   const cfg = VARIANTS[variant];
-  const { products, totalCount, loading, refresh } =
+  const { products, totalCount, truncated, loading, refresh } =
     useFetchDeliverables(variant);
 
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortBy>("freshness");
 
-  // Categorías presentes (por CVE_LIN) para los chips de filtro.
+  // Productos que matchean la búsqueda (sin aplicar aún el filtro de categoría):
+  // base común para los chips y el grid.
+  const queryFiltered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return products;
+    return products.filter(
+      (p) =>
+        p.product_name?.toLowerCase().includes(q) ||
+        p.product_id?.toLowerCase().includes(q)
+    );
+  }, [products, query]);
+
+  // Categorías presentes (por CVE_LIN) para los chips. Se cuentan sobre lo que
+  // matchea la búsqueda (no sobre la categoría seleccionada) para que el número
+  // del chip concuerde con lo visible y no se vacíe al elegir una categoría.
   const categories: Category[] = useMemo(() => {
     const map = new Map<string, Category>();
-    for (const p of products) {
+    for (const p of queryFiltered) {
       const id = p.type_id ?? "";
       const existing = map.get(id);
       if (existing) existing.count += 1;
@@ -91,19 +105,12 @@ export default function DeliverablesScreen({
         });
     }
     return Array.from(map.values()).sort((a, b) => b.count - a.count);
-  }, [products]);
+  }, [queryFiltered]);
 
   const visible = useMemo(() => {
-    let list = products;
+    let list = queryFiltered;
     if (selectedCategory != null)
       list = list.filter((p) => (p.type_id ?? "") === selectedCategory);
-    const q = query.trim().toLowerCase();
-    if (q)
-      list = list.filter(
-        (p) =>
-          p.product_name?.toLowerCase().includes(q) ||
-          p.product_id?.toLowerCase().includes(q)
-      );
 
     const sorted = [...list];
     if (sortBy === "quantity")
@@ -114,11 +121,13 @@ export default function DeliverablesScreen({
       );
     // "freshness" ya viene ordenado del hook (caduca antes primero)
     return sorted;
-  }, [products, selectedCategory, query, sortBy]);
+  }, [queryFiltered, selectedCategory, sortBy]);
 
-  const available = screenW - H_PADDING * 2;
+  // Clamp: en el primer render (web) useWindowDimensions puede reportar 0;
+  // evitamos un ancho de tarjeta negativo.
+  const available = Math.max(0, screenW - H_PADDING * 2);
   const numColumns = Math.max(2, Math.floor((available + GAP) / (MIN_CARD + GAP)));
-  const cardWidth = (available - GAP * (numColumns - 1)) / numColumns;
+  const cardWidth = Math.max(120, (available - GAP * (numColumns - 1)) / numColumns);
 
   const openMenu = () => navigation.dispatch(DrawerActions.openDrawer());
 
@@ -235,6 +244,35 @@ export default function DeliverablesScreen({
             onSelect={setSelectedCategory}
             isDark={isDark}
           />
+        </View>
+      )}
+
+      {/* Aviso de lista parcial (si el bucket excede una página de lotes) */}
+      {truncated && (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 8,
+            marginHorizontal: 16,
+            marginBottom: 6,
+            paddingVertical: 8,
+            paddingHorizontal: 12,
+            borderRadius: 10,
+            backgroundColor: isDark ? "#3a2f12" : "#fef3cd",
+          }}
+        >
+          <Ionicons
+            name="information-circle-outline"
+            size={18}
+            color={isDark ? "#fbbf24" : "#92700e"}
+          />
+          <Text
+            style={{ flex: 1, fontSize: 12, color: isDark ? "#fcd34d" : "#92700e" }}
+          >
+            Lista parcial: hay más lotes de los que caben aquí. Afina con la
+            búsqueda o las categorías.
+          </Text>
         </View>
       )}
 

--- a/frontend/components/DeliverablesScreen/DeliverablesScreen.tsx
+++ b/frontend/components/DeliverablesScreen/DeliverablesScreen.tsx
@@ -1,0 +1,400 @@
+import React, { useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  FlatList,
+  ActivityIndicator,
+  TouchableOpacity,
+  RefreshControl,
+  useWindowDimensions,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
+import { DrawerActions } from "@react-navigation/native";
+import { useSelector } from "react-redux";
+import { selectTheme } from "@/slices/themeSlice";
+import { themeColors } from "@/theme";
+import useFetchDeliverables from "@/hooks/useFetchDeliverables";
+import DeliverableCard from "@/components/DeliverableCard/DeliverableCard";
+import CategoryChips, { Category } from "@/components/CategoryChips/CategoryChips";
+import { DeliverableVariant } from "@/types/DeliverableProduct";
+
+type SortBy = "freshness" | "quantity" | "name";
+
+const H_PADDING = 16;
+const GAP = 16;
+const MIN_CARD = 200;
+
+const VARIANTS = {
+  entregable: {
+    title: "Productos entregables",
+    accent: "#78af6d",
+    icon: "cart-check" as const,
+    summary: (n: number) =>
+      `${n} ${n === 1 ? "producto listo" : "productos listos"} para entregar`,
+    emptyIcon: "package-variant" as const,
+    emptyTitle: "Aún no hay productos entregables",
+    emptyBody:
+      "La frescura se calcula desde los lotes con caducidad capturada en Aspel. En cuanto se registren lote y caducidad en las entradas, los productos aptos aparecerán aquí.",
+  },
+  noapto: {
+    title: "Productos no aptos",
+    accent: "#d65f61",
+    icon: "cart-remove" as const,
+    summary: (n: number) =>
+      `${n} ${n === 1 ? "producto requiere" : "productos requieren"} atención`,
+    emptyIcon: "check-decagram" as const,
+    emptyTitle: "Nada marcado como no apto",
+    emptyBody:
+      "Aquí aparecen los lotes caducados, por caducar (≤2 días) o sin caducidad capturada. Hoy no hay ninguno en ese estado.",
+  },
+} as const;
+
+// Pantalla compartida por "Productos entregables" y "Productos no aptos": mismo
+// grid de tarjetas, cambia el bucket (variant), el acento y los textos. Los
+// datos salen de useFetchDeliverables (que filtra por caducidad en el backend).
+export default function DeliverablesScreen({
+  variant,
+}: {
+  variant: DeliverableVariant;
+}) {
+  const theme = useSelector(selectTheme);
+  const isDark = theme === "dark";
+  const navigation = useNavigation();
+  const { width: screenW } = useWindowDimensions();
+
+  const cfg = VARIANTS[variant];
+  const { products, totalCount, loading, refresh } =
+    useFetchDeliverables(variant);
+
+  const [query, setQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<SortBy>("freshness");
+
+  // Categorías presentes (por CVE_LIN) para los chips de filtro.
+  const categories: Category[] = useMemo(() => {
+    const map = new Map<string, Category>();
+    for (const p of products) {
+      const id = p.type_id ?? "";
+      const existing = map.get(id);
+      if (existing) existing.count += 1;
+      else
+        map.set(id, {
+          id,
+          label: p.type || "Sin categoría",
+          typeId: p.type_id,
+          type: p.type,
+          count: 1,
+        });
+    }
+    return Array.from(map.values()).sort((a, b) => b.count - a.count);
+  }, [products]);
+
+  const visible = useMemo(() => {
+    let list = products;
+    if (selectedCategory != null)
+      list = list.filter((p) => (p.type_id ?? "") === selectedCategory);
+    const q = query.trim().toLowerCase();
+    if (q)
+      list = list.filter(
+        (p) =>
+          p.product_name?.toLowerCase().includes(q) ||
+          p.product_id?.toLowerCase().includes(q)
+      );
+
+    const sorted = [...list];
+    if (sortBy === "quantity")
+      sorted.sort((a, b) => b.total_quantity - a.total_quantity);
+    else if (sortBy === "name")
+      sorted.sort((a, b) =>
+        (a.product_name || "").localeCompare(b.product_name || "")
+      );
+    // "freshness" ya viene ordenado del hook (caduca antes primero)
+    return sorted;
+  }, [products, selectedCategory, query, sortBy]);
+
+  const available = screenW - H_PADDING * 2;
+  const numColumns = Math.max(2, Math.floor((available + GAP) / (MIN_CARD + GAP)));
+  const cardWidth = (available - GAP * (numColumns - 1)) / numColumns;
+
+  const openMenu = () => navigation.dispatch(DrawerActions.openDrawer());
+
+  return (
+    <SafeAreaView
+      edges={["top", "left", "right"]}
+      style={{ flex: 1, backgroundColor: themeColors.background(isDark) }}
+    >
+      {/* Hero */}
+      <LinearGradient
+        colors={[cfg.accent + (isDark ? "33" : "22"), themeColors.background(isDark)]}
+        style={{ paddingHorizontal: H_PADDING, paddingTop: 12, paddingBottom: 14 }}
+      >
+        <View style={{ flexDirection: "row", alignItems: "center" }}>
+          <TouchableOpacity
+            onPress={openMenu}
+            style={{ padding: 6, marginRight: 6 }}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <Ionicons
+              name="menu"
+              size={28}
+              color={themeColors.text(isDark)}
+            />
+          </TouchableOpacity>
+          <View
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 12,
+              backgroundColor: cfg.accent,
+              alignItems: "center",
+              justifyContent: "center",
+              marginRight: 10,
+            }}
+          >
+            <MaterialCommunityIcons name={cfg.icon} size={24} color="#fff" />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text
+              style={{
+                fontSize: 22,
+                fontWeight: "800",
+                color: themeColors.text(isDark),
+              }}
+            >
+              {cfg.title}
+            </Text>
+            <Text
+              style={{
+                fontSize: 13,
+                color: isDark ? "#a1a1aa" : "#52525b",
+                marginTop: 1,
+              }}
+            >
+              {cfg.summary(totalCount)}
+            </Text>
+          </View>
+          <SortButton sortBy={sortBy} setSortBy={setSortBy} isDark={isDark} />
+        </View>
+
+        {/* Buscador */}
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            marginTop: 12,
+            backgroundColor: isDark ? "#1f2937" : "#ffffff",
+            borderRadius: 14,
+            paddingHorizontal: 12,
+            height: 44,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 2 },
+            shadowOpacity: isDark ? 0.3 : 0.08,
+            shadowRadius: 4,
+            elevation: 2,
+          }}
+        >
+          <Ionicons
+            name="search-outline"
+            size={18}
+            color={isDark ? "#9ca3af" : "#6b7280"}
+          />
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Buscar por nombre o clave…"
+            placeholderTextColor={isDark ? "#6b7280" : "#9ca3af"}
+            style={{
+              flex: 1,
+              marginLeft: 8,
+              fontSize: 15,
+              color: themeColors.text(isDark),
+            }}
+          />
+          {query.length > 0 && (
+            <TouchableOpacity onPress={() => setQuery("")}>
+              <Ionicons
+                name="close-circle"
+                size={18}
+                color={isDark ? "#6b7280" : "#9ca3af"}
+              />
+            </TouchableOpacity>
+          )}
+        </View>
+      </LinearGradient>
+
+      {/* Chips de categoría */}
+      {categories.length > 0 && (
+        <View style={{ paddingVertical: 6 }}>
+          <CategoryChips
+            categories={categories}
+            selected={selectedCategory}
+            onSelect={setSelectedCategory}
+            isDark={isDark}
+          />
+        </View>
+      )}
+
+      {/* Grid */}
+      {loading && products.length === 0 ? (
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <ActivityIndicator size="large" color={cfg.accent} />
+        </View>
+      ) : (
+        <FlatList
+          key={numColumns}
+          data={visible}
+          keyExtractor={(p) => p.product_id}
+          numColumns={numColumns}
+          columnWrapperStyle={numColumns > 1 ? { gap: GAP } : undefined}
+          contentContainerStyle={{
+            paddingHorizontal: H_PADDING,
+            paddingTop: 8,
+            paddingBottom: 32,
+            gap: GAP,
+            flexGrow: 1,
+          }}
+          renderItem={({ item }) => (
+            <DeliverableCard
+              product={item}
+              variant={variant}
+              width={cardWidth}
+              isDark={isDark}
+            />
+          )}
+          refreshControl={
+            <RefreshControl
+              refreshing={loading}
+              onRefresh={refresh}
+              tintColor={cfg.accent}
+              colors={[cfg.accent]}
+            />
+          }
+          ListEmptyComponent={
+            <EmptyState
+              icon={cfg.emptyIcon}
+              title={query || selectedCategory ? "Sin resultados" : cfg.emptyTitle}
+              body={
+                query || selectedCategory
+                  ? "Prueba con otra búsqueda o quita el filtro de categoría."
+                  : cfg.emptyBody
+              }
+              isDark={isDark}
+            />
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+type IconName = React.ComponentProps<typeof MaterialCommunityIcons>["name"];
+
+function SortButton({
+  sortBy,
+  setSortBy,
+  isDark,
+}: {
+  sortBy: SortBy;
+  setSortBy: (s: SortBy) => void;
+  isDark: boolean;
+}) {
+  const order: SortBy[] = ["freshness", "quantity", "name"];
+  const labels: Record<SortBy, string> = {
+    freshness: "Frescura",
+    quantity: "Cantidad",
+    name: "Nombre",
+  };
+  const next = () =>
+    setSortBy(order[(order.indexOf(sortBy) + 1) % order.length]);
+  return (
+    <TouchableOpacity
+      onPress={next}
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: 10,
+        paddingVertical: 7,
+        borderRadius: 10,
+        backgroundColor: isDark ? "#1f2937" : "#ffffff",
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: isDark ? 0.3 : 0.08,
+        shadowRadius: 3,
+        elevation: 2,
+      }}
+    >
+      <MaterialCommunityIcons
+        name="sort"
+        size={15}
+        color={isDark ? "#d1d5db" : "#374151"}
+      />
+      <Text
+        style={{
+          marginLeft: 5,
+          fontSize: 12,
+          fontWeight: "600",
+          color: isDark ? "#d1d5db" : "#374151",
+        }}
+      >
+        {labels[sortBy]}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function EmptyState({
+  icon,
+  title,
+  body,
+  isDark,
+}: {
+  icon: IconName;
+  title: string;
+  body: string;
+  isDark: boolean;
+}) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 32,
+        paddingVertical: 48,
+      }}
+    >
+      <MaterialCommunityIcons
+        name={icon}
+        size={64}
+        color={isDark ? "#3f3f46" : "#d4d4d8"}
+      />
+      <Text
+        style={{
+          marginTop: 16,
+          fontSize: 17,
+          fontWeight: "700",
+          color: isDark ? "#e4e4e7" : "#3f3f46",
+          textAlign: "center",
+        }}
+      >
+        {title}
+      </Text>
+      <Text
+        style={{
+          marginTop: 8,
+          fontSize: 13,
+          lineHeight: 19,
+          color: isDark ? "#a1a1aa" : "#71717a",
+          textAlign: "center",
+          maxWidth: 440,
+        }}
+      >
+        {body}
+      </Text>
+    </View>
+  );
+}

--- a/frontend/components/FreshnessDots/FreshnessDots.tsx
+++ b/frontend/components/FreshnessDots/FreshnessDots.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { View } from "react-native";
+
+type Props = {
+  dots: number; // cuántos puntos van "llenos"
+  color: string;
+  total?: number;
+  size?: number;
+};
+
+// Indicador de frescura tipo "señal": N de 5 puntos llenos del color del bucket.
+// Más puntos llenos = más holgura antes de caducar.
+export default function FreshnessDots({
+  dots,
+  color,
+  total = 5,
+  size = 8,
+}: Props) {
+  return (
+    <View style={{ flexDirection: "row", gap: 4 }}>
+      {Array.from({ length: total }).map((_, i) => (
+        <View
+          key={i}
+          style={{
+            width: size,
+            height: size,
+            borderRadius: size / 2,
+            borderWidth: 1.5,
+            borderColor: color,
+            backgroundColor: i < dots ? color : "transparent",
+          }}
+        />
+      ))}
+    </View>
+  );
+}

--- a/frontend/components/ProductRow/ProductRow.tsx
+++ b/frontend/components/ProductRow/ProductRow.tsx
@@ -11,6 +11,7 @@ import { InventoryItem } from "@/types/InventoryItem";
 import { Lot } from "@/types/Lot";
 import DefaultProductImage from "@/components/DefaultProductImage/DefaultProductImage";
 import { unitForLine } from "@/functions/unitForLine";
+import { formatQuantity } from "@/functions/formatQuantity";
 
 import { navigate } from "@/functions/NavigationService";
 
@@ -296,16 +297,6 @@ export default function ProductRow({
       </View>
     </View>
   );
-}
-function formatQuantity(value: unknown): string {
-  const n = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(n)) return "0";
-  // Threshold 0.01: descarta ruido de Aspel (residuos tipo 1e-12 que dejan
-  // las sumas/restas de movimientos) y también valores residuales escalados
-  // como 0.01 que en piezas significa "casi nada". Sincronizado con
-  // hasStock arriba y con InveRepository.findAllInveWithStock en backend.
-  if (Math.abs(n) < 0.01) return "0";
-  return n.toLocaleString("es-MX", { maximumFractionDigits: 2 });
 }
 
 function formatDateProduction(dateStr: string) {

--- a/frontend/components/SideBar/SideBar.tsx
+++ b/frontend/components/SideBar/SideBar.tsx
@@ -174,6 +174,7 @@ export default function SideBar({ navigation }: DrawerContentComponentProps) {
               <TouchableOpacity
                 className="flex-row items-center justify-center m-4 rounded-2xl"
                 style={button(true, width, height)}
+                onPress={() => navigate("ProductosEntregables")}
               >
                 <View className="flex-row items-center p-6">
                   <FontAwesome6
@@ -193,6 +194,7 @@ export default function SideBar({ navigation }: DrawerContentComponentProps) {
               <TouchableOpacity
                 className="flex-row items-center justify-center m-4 rounded-2xl"
                 style={button(false, width, height)}
+                onPress={() => navigate("ProductosNoAptos")}
               >
                 <View className="flex-row items-center p-6">
                   <FontAwesome6

--- a/frontend/functions/NavigationService.ts
+++ b/frontend/functions/NavigationService.ts
@@ -40,6 +40,10 @@ function convertRouteToPath(routeName: string): string {
       return "/(drawer)/inicio";
     case "Inventario":
       return "/(drawer)/inventario";
+    case "ProductosEntregables":
+      return "/(drawer)/productosEntregables";
+    case "ProductosNoAptos":
+      return "/(drawer)/productosNoAptos";
     case "Configuracion":
       return "/(drawer)/configuracion";
     case "Usuario":

--- a/frontend/functions/formatQuantity.ts
+++ b/frontend/functions/formatQuantity.ts
@@ -1,0 +1,11 @@
+// Formatea cantidades provenientes de Aspel: descarta ruido de punto flotante
+// (residuos tipo 1e-12 que dejan las sumas/restas de movimientos) y valores
+// residuales escalados (< 0.01) que no son stock operativo, y aplica locale
+// es-MX. Extraído de ProductRow para reusarlo en las pantallas de entregables
+// / no aptos y mantener una sola fuente de verdad del formateo de cantidades.
+export function formatQuantity(value: unknown): string {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "0";
+  if (Math.abs(n) < 0.01) return "0";
+  return n.toLocaleString("es-MX", { maximumFractionDigits: 2 });
+}

--- a/frontend/functions/getFreshness.ts
+++ b/frontend/functions/getFreshness.ts
@@ -1,0 +1,69 @@
+import { DeliverableVariant } from "@/types/DeliverableProduct";
+
+// Colores del indicador de frescura. Alineados con el semáforo del Home.
+export const FRESHNESS_GREEN = "#52C41A";
+export const FRESHNESS_AMBER = "#FFC107";
+export const FRESHNESS_RED = "#FF4D4F";
+
+export type Freshness = {
+  dots: number; // puntos "llenos" de un total de 5 (más = más fresco)
+  color: string;
+  label: string;
+  daysLeft: number | null; // null = sin caducidad capturada
+};
+
+// Días de calendario entre hoy y la caducidad (trunca la hora). Negativo = ya
+// caducó. null si no hay fecha o no es parseable.
+function daysUntil(expiration: string | null): number | null {
+  if (!expiration) return null;
+  const exp = new Date(expiration);
+  if (Number.isNaN(exp.getTime())) return null;
+  const today = new Date();
+  const a = Date.UTC(today.getFullYear(), today.getMonth(), today.getDate());
+  const b = Date.UTC(exp.getFullYear(), exp.getMonth(), exp.getDate());
+  return Math.round((b - a) / 86_400_000);
+}
+
+function dotsForDays(daysLeft: number | null): number {
+  if (daysLeft == null) return 0;
+  if (daysLeft >= 15) return 5;
+  if (daysLeft >= 10) return 4;
+  if (daysLeft >= 6) return 3;
+  if (daysLeft >= 3) return 2; // warning (3-5 días)
+  if (daysLeft >= 1) return 1;
+  return 0;
+}
+
+function plural(n: number, singular: string, pluralForm: string): string {
+  return Math.abs(n) === 1 ? singular : pluralForm;
+}
+
+// Traduce la caducidad de un producto a un indicador visual de frescura según
+// el bucket. En entregables la frescura va de amarillo (por caducar, 3-5 días)
+// a verde (holgado). En no aptos siempre es rojo y el label explica el porqué.
+export function getFreshness(
+  expiration: string | null,
+  variant: DeliverableVariant
+): Freshness {
+  const daysLeft = daysUntil(expiration);
+
+  if (variant === "noapto") {
+    let label: string;
+    if (daysLeft == null) label = "Sin caducidad";
+    else if (daysLeft < 0)
+      label = `Caducó hace ${Math.abs(daysLeft)} ${plural(daysLeft, "día", "días")}`;
+    else if (daysLeft === 0) label = "Caduca hoy";
+    else label = `Caduca en ${daysLeft} ${plural(daysLeft, "día", "días")}`;
+    return { dots: 0, color: FRESHNESS_RED, label, daysLeft };
+  }
+
+  // entregable: verde si caduca holgado (> 5 días), amarillo si está por caducar.
+  const color = daysLeft != null && daysLeft > 5 ? FRESHNESS_GREEN : FRESHNESS_AMBER;
+  const label =
+    daysLeft == null
+      ? "Sin caducidad"
+      : daysLeft === 1
+        ? "Caduca mañana"
+        : `Caduca en ${daysLeft} ${plural(daysLeft, "día", "días")}`;
+  return { dots: dotsForDays(daysLeft), color, label, daysLeft };
+}

--- a/frontend/hooks/useFetchDeliverables.ts
+++ b/frontend/hooks/useFetchDeliverables.ts
@@ -1,0 +1,97 @@
+import { apiService } from "@/api/apiService";
+import { Lot } from "@/types/Lot";
+import {
+  DeliverableProduct,
+  DeliverableVariant,
+} from "@/types/DeliverableProduct";
+import { useCallback, useEffect, useState } from "react";
+
+// La caducidad "más temprana" gana. null (sin caducidad capturada) domina: en
+// no aptos es lo más crítico/desconocido, así que ese producto se muestra como
+// "Sin caducidad".
+function earlier(a: string | null, b: string | null): string | null {
+  if (a == null) return a;
+  if (b == null) return b;
+  return new Date(a).getTime() <= new Date(b).getTime() ? a : b;
+}
+
+// Colapsa los lotes (LTPD) en una tarjeta por producto: suma cantidades y se
+// queda con la caducidad más próxima. Ordena por frescura ascendente (lo que
+// caduca antes primero; sin caducidad al frente por ser lo más crítico).
+function aggregateByProduct(lots: Lot[]): DeliverableProduct[] {
+  const byId = new Map<string, DeliverableProduct>();
+
+  for (const lot of lots) {
+    if (!lot?.product_id) continue;
+    const qty = Number(lot.available_quantity) || 0;
+    const current = byId.get(lot.product_id);
+
+    if (!current) {
+      byId.set(lot.product_id, {
+        product_id: lot.product_id,
+        product_name: lot.product_name,
+        type: lot.type ?? null,
+        type_id: lot.type_id ?? null,
+        image: lot.image ?? null,
+        total_quantity: qty,
+        nearest_expiration: lot.expiration_date ?? null,
+        lots_count: 1,
+      });
+    } else {
+      current.total_quantity += qty;
+      current.lots_count += 1;
+      current.nearest_expiration = earlier(
+        current.nearest_expiration,
+        lot.expiration_date ?? null
+      );
+      if (!current.image && lot.image) current.image = lot.image;
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => {
+    if (a.nearest_expiration == null) return -1;
+    if (b.nearest_expiration == null) return 1;
+    return (
+      new Date(a.nearest_expiration).getTime() -
+      new Date(b.nearest_expiration).getTime()
+    );
+  });
+}
+
+// Trae los lotes del bucket pedido desde /api/lotes/ (el backend filtra por
+// fitForDelivery) y los agrega por producto. size=500 cubre con holgura el
+// volumen real de lotes capturados en BAMX hoy; el filtro mantiene el payload
+// chico. Si el API falla, retrievaData devuelve undefined -> lista vacía ->
+// empty state honesto en la pantalla.
+export function useFetchDeliverables(variant: DeliverableVariant) {
+  const [products, setProducts] = useState<DeliverableProduct[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const fitForDelivery = variant === "entregable";
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const data = await apiService.retrieveData(
+      `/api/lotes/?fitForDelivery=${fitForDelivery}&size=500&sort=fchCaduc&direction=asc`
+    );
+    const lots: Lot[] = data?.content ?? [];
+    setProducts(aggregateByProduct(lots));
+    setLoading(false);
+  }, [fitForDelivery]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const totalQuantity = products.reduce((sum, p) => sum + p.total_quantity, 0);
+
+  return {
+    products,
+    totalQuantity,
+    totalCount: products.length,
+    loading,
+    refresh: load,
+  };
+}
+
+export default useFetchDeliverables;

--- a/frontend/hooks/useFetchDeliverables.ts
+++ b/frontend/hooks/useFetchDeliverables.ts
@@ -6,6 +6,11 @@ import {
 } from "@/types/DeliverableProduct";
 import { useCallback, useEffect, useState } from "react";
 
+// Una sola página cubre con holgura el volumen real de lotes de BAMX. El backend
+// pagina, así que si algún bucket llegara a superar esto exponemos `truncated`
+// para que la pantalla avise en vez de esconder productos en silencio.
+const PAGE_SIZE = 500;
+
 // La caducidad "más temprana" gana. null (sin caducidad capturada) domina: en
 // no aptos es lo más crítico/desconocido, así que ese producto se muestra como
 // "Sin caducidad".
@@ -59,22 +64,23 @@ function aggregateByProduct(lots: Lot[]): DeliverableProduct[] {
 }
 
 // Trae los lotes del bucket pedido desde /api/lotes/ (el backend filtra por
-// fitForDelivery) y los agrega por producto. size=500 cubre con holgura el
-// volumen real de lotes capturados en BAMX hoy; el filtro mantiene el payload
-// chico. Si el API falla, retrievaData devuelve undefined -> lista vacía ->
-// empty state honesto en la pantalla.
+// fitForDelivery) y los agrega por producto. Si el API falla, retrieveData
+// devuelve undefined -> lista vacía -> empty state honesto en la pantalla.
 export function useFetchDeliverables(variant: DeliverableVariant) {
   const [products, setProducts] = useState<DeliverableProduct[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [truncated, setTruncated] = useState<boolean>(false);
 
   const fitForDelivery = variant === "entregable";
 
   const load = useCallback(async () => {
     setLoading(true);
     const data = await apiService.retrieveData(
-      `/api/lotes/?fitForDelivery=${fitForDelivery}&size=500&sort=fchCaduc&direction=asc`
+      `/api/lotes/?fitForDelivery=${fitForDelivery}&size=${PAGE_SIZE}&sort=fchCaduc&direction=asc`
     );
     const lots: Lot[] = data?.content ?? [];
+    // `last === false` => el backend tiene más páginas de las que pedimos.
+    setTruncated(data?.last === false);
     setProducts(aggregateByProduct(lots));
     setLoading(false);
   }, [fitForDelivery]);
@@ -83,12 +89,10 @@ export function useFetchDeliverables(variant: DeliverableVariant) {
     load();
   }, [load]);
 
-  const totalQuantity = products.reduce((sum, p) => sum + p.total_quantity, 0);
-
   return {
     products,
-    totalQuantity,
     totalCount: products.length,
+    truncated,
     loading,
     refresh: load,
   };

--- a/frontend/screens/ProductosEntregablesScreen/ProductosEntregablesScreen.tsx
+++ b/frontend/screens/ProductosEntregablesScreen/ProductosEntregablesScreen.tsx
@@ -1,0 +1,5 @@
+import DeliverablesScreen from "@/components/DeliverablesScreen/DeliverablesScreen";
+
+export default function ProductosEntregablesScreen() {
+  return <DeliverablesScreen variant="entregable" />;
+}

--- a/frontend/screens/ProductosNoAptosScreen/ProductosNoAptosScreen.tsx
+++ b/frontend/screens/ProductosNoAptosScreen/ProductosNoAptosScreen.tsx
@@ -1,0 +1,5 @@
+import DeliverablesScreen from "@/components/DeliverablesScreen/DeliverablesScreen";
+
+export default function ProductosNoAptosScreen() {
+  return <DeliverablesScreen variant="noapto" />;
+}

--- a/frontend/types/DeliverableProduct.ts
+++ b/frontend/types/DeliverableProduct.ts
@@ -1,0 +1,19 @@
+// Variante de pantalla / bucket de caducidad:
+//  - "entregable": semáforo verde+amarillo (apto para entregar).
+//  - "noapto": semáforo rojo (caducado, por caducar o sin caducidad capturada).
+export type DeliverableVariant = "entregable" | "noapto";
+
+// Producto agregado desde sus lotes (LTPD) para las pantallas de entregables /
+// no aptos. Una tarjeta = un producto: total_quantity suma los lotes del bucket
+// y nearest_expiration es la caducidad más próxima (la más conservadora, que
+// alimenta el indicador de frescura de la tarjeta).
+export type DeliverableProduct = {
+  product_id: string;
+  product_name: string;
+  type: string | null;
+  type_id: string | null;
+  image: string | null;
+  total_quantity: number;
+  nearest_expiration: string | null;
+  lots_count: number;
+};


### PR DESCRIPTION
## Qué hace

Convierte los dos botones grandes del SideBar —"Productos entregables" (verde) y
"Productos no aptos" (rojo), que no tenían `onPress`— en dos pantallas reales con
grid de tarjetas pensado para tablets Android.

El bucket lo decide la caducidad de los lotes (LTPD):
- **Entregable** = semáforo verde+amarillo (`fchCaduc > hoy+2`)
- **No apto** = semáforo rojo (caducados, por caducar ≤2 días, o sin caducidad capturada)

## Backend
- `/api/lotes/` acepta un param **opcional** `fitForDelivery` (`true`=entregables,
  `false`=no aptos, ausente=todos → **el Semáforo no se toca**).
- Dos queries dedicadas en `LtpdRepository` con frontera `fchCaduc >= medianoche de
  hoy+3`, alineada exacto con la clasificación `days>2` de `LtpdService`.
- 100% read-only (solo SELECT). Tests de `LtpdService` extendidos.

## Frontend
- `DeliverablesScreen` compartido por `variant`: hero con gradiente del acento,
  buscador, chips de categoría (icono+color por línea), orden frescura/cantidad/
  nombre, grid responsivo por ancho de tablet, indicador de frescura
  (puntos+color+días), tap → modal Details, pull-to-refresh y dark mode.
- `useFetchDeliverables` (agrega lotes por producto), `getFreshness`,
  `FreshnessDots`, `DeliverableCard`, `CategoryChips`.
- Empty state honesto + aviso de "lista parcial" si un bucket excede una página.
- Cableo de los botones del SideBar + rutas en Expo Router.

## Cómo probar
- Backend: `./mvnw -Djacoco.skip=true test` → 8 verde.
- Frontend: `npm run test` → 19 suites / 131 verde.
- Manual: `npx expo start` → menú lateral → Productos entregables / no aptos.

## Notas
- **Read-only** contra Aspel (sin botones de acción).
- Depende de la captura de lote+caducidad en Aspel: con los datos actuales
  (LTPD ~6 lotes) las pantallas nacen poco pobladas **por diseño** — el empty
  state lo explica y se llenan solas conforme BAMX capture caducidad.
- Incluye mejoras de un code review previo (aviso de truncamiento, clamp de
  ancho, contadores de chips, limpieza de código muerto).